### PR TITLE
Remove more model summary tests

### DIFF
--- a/python/ql/test/experimental/dataflow/model-summaries/TestSummaries.qll
+++ b/python/ql/test/experimental/dataflow/model-summaries/TestSummaries.qll
@@ -11,14 +11,10 @@ private class StepsFromModel extends ModelInput::SummaryModelCsv {
         "foo;Member[MS_apply_lambda];Argument[1];Argument[0].Parameter[0];value",
         "foo;Member[MS_apply_lambda];Argument[0].ReturnValue;ReturnValue;value",
         "foo;Member[MS_reversed];Argument[0].ListElement;ReturnValue.ListElement;value",
-        "foo;Member[MS_reversed];Argument[0];ReturnValue;taint",
         "foo;Member[MS_list_map];Argument[1].ListElement;Argument[0].Parameter[0];value",
         "foo;Member[MS_list_map];Argument[0].ReturnValue;ReturnValue.ListElement;value",
-        "foo;Member[MS_list_map];Argument[1];ReturnValue;taint",
         "foo;Member[MS_append_to_list];Argument[0].ListElement;ReturnValue.ListElement;value",
         "foo;Member[MS_append_to_list];Argument[1];ReturnValue.ListElement;value",
-        "foo;Member[MS_append_to_list];Argument[0];ReturnValue;taint",
-        "foo;Member[MS_append_to_list];Argument[1];ReturnValue;taint",
         "json;Member[MS_loads];Argument[0];ReturnValue;taint"
       ]
   }

--- a/python/ql/test/experimental/dataflow/model-summaries/model_summaries.py
+++ b/python/ql/test/experimental/dataflow/model-summaries/model_summaries.py
@@ -49,11 +49,6 @@ SINK_F(not_via_lambda)
 via_reversed = MS_reversed([SOURCE])
 SINK(via_reversed[0])  # $ flow="SOURCE, l:-1 -> via_reversed[0]"
 
-tainted_list = MS_reversed([TAINTED_STRING])
-ensure_tainted(
-    tainted_list,  # $ tainted
-    tainted_list[0],  # $ tainted
-)
 
 # Complex summaries
 def box(x):
@@ -62,11 +57,6 @@ def box(x):
 via_map = MS_list_map(box, [SOURCE])
 SINK(via_map[0][0])  # $ flow="SOURCE, l:-1 -> via_map[0][0]"
 
-tainted_mapped = MS_list_map(box, [TAINTED_STRING])
-ensure_tainted(
-    tainted_mapped,  # $ tainted
-    tainted_mapped[0][0],  # $ tainted
-)
 
 def explicit_identity(x):
     return x
@@ -74,38 +64,18 @@ def explicit_identity(x):
 via_map_explicit = MS_list_map(explicit_identity, [SOURCE])
 SINK(via_map_explicit[0])  # $ flow="SOURCE, l:-1 -> via_map_explicit[0]"
 
-tainted_mapped_explicit = MS_list_map(explicit_identity, [TAINTED_STRING])
-ensure_tainted(
-    tainted_mapped_explicit,  # $ tainted
-    tainted_mapped_explicit[0],  # $ tainted
-)
 
 via_map_summary = MS_list_map(MS_identity, [SOURCE])
 SINK(via_map_summary[0])  # $ flow="SOURCE, l:-1 -> via_map_summary[0]"
 
-tainted_mapped_summary = MS_list_map(MS_identity, [TAINTED_STRING])
-ensure_tainted(
-    tainted_mapped_summary,  # $ tainted
-    tainted_mapped_summary[0],  # $ tainted
-)
 
 via_append_el = MS_append_to_list([], SOURCE)
 SINK(via_append_el[0])  # $ flow="SOURCE, l:-1 -> via_append_el[0]"
 
-tainted_list_el = MS_append_to_list([], TAINTED_STRING)
-ensure_tainted(
-    tainted_list_el,  # $ tainted
-    tainted_list_el[0],  # $ tainted
-)
 
 via_append = MS_append_to_list([SOURCE], NONSOURCE)
 SINK(via_append[0])  # $ flow="SOURCE, l:-1 -> via_append[0]"
 
-tainted_list_implicit = MS_append_to_list([TAINTED_STRING], NONSOURCE)
-ensure_tainted(
-    tainted_list,  # $ tainted
-    tainted_list[0],  # $ tainted
-)
 
 # Modeled flow-summary is not value preserving
 from json import MS_loads as json_loads

--- a/python/ql/test/experimental/dataflow/model-summaries/model_summaries.py
+++ b/python/ql/test/experimental/dataflow/model-summaries/model_summaries.py
@@ -49,7 +49,7 @@ SINK_F(not_via_lambda)
 via_reversed = MS_reversed([SOURCE])
 SINK(via_reversed[0])  # $ flow="SOURCE, l:-1 -> via_reversed[0]"
 
-tainted_list = MS_reversed(TAINTED_LIST)
+tainted_list = MS_reversed([TAINTED_STRING])
 ensure_tainted(
     tainted_list,  # $ tainted
     tainted_list[0],  # $ tainted
@@ -62,7 +62,7 @@ def box(x):
 via_map = MS_list_map(box, [SOURCE])
 SINK(via_map[0][0])  # $ flow="SOURCE, l:-1 -> via_map[0][0]"
 
-tainted_mapped = MS_list_map(box, TAINTED_LIST)
+tainted_mapped = MS_list_map(box, [TAINTED_STRING])
 ensure_tainted(
     tainted_mapped,  # $ tainted
     tainted_mapped[0][0],  # $ tainted
@@ -74,7 +74,7 @@ def explicit_identity(x):
 via_map_explicit = MS_list_map(explicit_identity, [SOURCE])
 SINK(via_map_explicit[0])  # $ flow="SOURCE, l:-1 -> via_map_explicit[0]"
 
-tainted_mapped_explicit = MS_list_map(explicit_identity, TAINTED_LIST)
+tainted_mapped_explicit = MS_list_map(explicit_identity, [TAINTED_STRING])
 ensure_tainted(
     tainted_mapped_explicit,  # $ tainted
     tainted_mapped_explicit[0],  # $ tainted
@@ -83,7 +83,7 @@ ensure_tainted(
 via_map_summary = MS_list_map(MS_identity, [SOURCE])
 SINK(via_map_summary[0])  # $ flow="SOURCE, l:-1 -> via_map_summary[0]"
 
-tainted_mapped_summary = MS_list_map(MS_identity, TAINTED_LIST)
+tainted_mapped_summary = MS_list_map(MS_identity, [TAINTED_STRING])
 ensure_tainted(
     tainted_mapped_summary,  # $ tainted
     tainted_mapped_summary[0],  # $ tainted
@@ -101,7 +101,7 @@ ensure_tainted(
 via_append = MS_append_to_list([SOURCE], NONSOURCE)
 SINK(via_append[0])  # $ flow="SOURCE, l:-1 -> via_append[0]"
 
-tainted_list_implicit = MS_append_to_list(TAINTED_LIST, NONSOURCE)
+tainted_list_implicit = MS_append_to_list([TAINTED_STRING], NONSOURCE)
 ensure_tainted(
     tainted_list,  # $ tainted
     tainted_list[0],  # $ tainted


### PR DESCRIPTION
Thinking some more about this, I think these tests should be about
whether you can write flow summaries in CSV files that do the right
thing.

Having all these extra taint steps are closer to what our current
taint-tracking does in the end, but from my point of view, doesn't help
us achieve the goal of the tests.

So, I'm removing them.