### PR TITLE
Shared CFG: check abrupt completion origins

### DIFF
--- a/csharp/ql/test/library-tests/controlflow/graph/InvalidAbruptCompletionOrigin.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/InvalidAbruptCompletionOrigin.expected
@@ -1,0 +1,17 @@
+consistencyOverview
+siblingsWithSameIndexInDefaultCfg
+deadEnd
+nonUniqueEnclosingCallable
+nonUniqueInConditionalContext
+nonLocalStep
+ambiguousAdditionalNode
+invalidAbruptCompletionOrigin
+missingInNodeForPostOrInOrder
+multipleSuccessors
+multipleConditionalSuccessorKinds
+directAndConditionalSuccessors
+selfLoop
+bodyPartNonOverlap
+parameterNonOverlap
+parameterEnclosingCallable
+#select

--- a/csharp/ql/test/library-tests/controlflow/graph/InvalidAbruptCompletionOrigin.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/InvalidAbruptCompletionOrigin.ql
@@ -1,0 +1,6 @@
+import csharp
+import ControlFlow::Consistency
+
+from int results
+where consistencyOverview("invalidAbruptCompletionOrigin", results)
+select results

--- a/java/ql/test/library-tests/controlflow/basic/InvalidAbruptCompletionOrigin.expected
+++ b/java/ql/test/library-tests/controlflow/basic/InvalidAbruptCompletionOrigin.expected
@@ -1,0 +1,17 @@
+consistencyOverview
+siblingsWithSameIndexInDefaultCfg
+deadEnd
+nonUniqueEnclosingCallable
+nonUniqueInConditionalContext
+nonLocalStep
+ambiguousAdditionalNode
+invalidAbruptCompletionOrigin
+missingInNodeForPostOrInOrder
+multipleSuccessors
+multipleConditionalSuccessorKinds
+directAndConditionalSuccessors
+selfLoop
+bodyPartNonOverlap
+parameterNonOverlap
+parameterEnclosingCallable
+#select

--- a/java/ql/test/library-tests/controlflow/basic/InvalidAbruptCompletionOrigin.ql
+++ b/java/ql/test/library-tests/controlflow/basic/InvalidAbruptCompletionOrigin.ql
@@ -1,0 +1,6 @@
+import java
+import ControlFlow::Consistency
+
+from int results
+where consistencyOverview("invalidAbruptCompletionOrigin", results)
+select results

--- a/python/ql/test/library-tests/ControlFlow/successors/InvalidAbruptCompletionOrigin.expected
+++ b/python/ql/test/library-tests/ControlFlow/successors/InvalidAbruptCompletionOrigin.expected
@@ -1,0 +1,17 @@
+consistencyOverview
+siblingsWithSameIndexInDefaultCfg
+deadEnd
+nonUniqueEnclosingCallable
+nonUniqueInConditionalContext
+nonLocalStep
+ambiguousAdditionalNode
+invalidAbruptCompletionOrigin
+missingInNodeForPostOrInOrder
+multipleSuccessors
+multipleConditionalSuccessorKinds
+directAndConditionalSuccessors
+selfLoop
+bodyPartNonOverlap
+parameterNonOverlap
+parameterEnclosingCallable
+#select

--- a/python/ql/test/library-tests/ControlFlow/successors/InvalidAbruptCompletionOrigin.ql
+++ b/python/ql/test/library-tests/ControlFlow/successors/InvalidAbruptCompletionOrigin.ql
@@ -1,0 +1,6 @@
+import semmle.python.controlflow.internal.AstNodeImpl
+import ControlFlow::Consistency
+
+from int results
+where consistencyOverview("invalidAbruptCompletionOrigin", results)
+select results

--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -2257,6 +2257,12 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
             query = "missingInNodeForPostOrInOrder" and
             results = strictcount(AstNode ast | missingInNodeForPostOrInOrder(ast))
             or
+            query = "invalidAbruptCompletionOrigin" and
+            results =
+              strictcount(AstNode ast, PreControlFlowNode node |
+                invalidAbruptCompletionOrigin(ast, node)
+              )
+            or
             query = "multipleSuccessors" and
             results =
               strictcount(ControlFlowNode node, SuccessorType t, ControlFlowNode successor |
@@ -2339,6 +2345,16 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
            */
           query predicate ambiguousAdditionalNode(AstNode n, string tag) {
             1 < strictcount(NormalSuccessor t | additionalNode(n, tag, t))
+          }
+
+          /**
+           * Holds if the language-specific CFG input supplies an abrupt completion for `ast` whose
+           * origin `node` does not belong to `ast`.
+           */
+          query predicate invalidAbruptCompletionOrigin(AstNode ast, PreControlFlowNode node) {
+            Input2::beginAbruptCompletion(ast, node, _, _) and
+            not node.isIn(ast) and
+            not node.isAdditional(ast, _)
           }
 
           /**


### PR DESCRIPTION
## Summary

- add `invalidAbruptCompletionOrigin` to the shared CFG consistency checks;
- validate only language-supplied `Input2::beginAbruptCompletion` origins, requiring each origin to be either `node.isIn(ast)` or `node.isAdditional(ast, _)`;
- register the check in `consistencyOverview` and add generated overview tests for every current consumer: Java, C#, and Python.

This intentionally does not inspect the shared library's combined private `beginAbruptCompletion`, whose unmatched final catch-clause completion legitimately originates at `isAfterValue`.

## Motivation

This follows the consistency-check suggestion from review of #22380: https://github.com/github/codeql/pull/22380#discussion_r3820925554. The change is independent of #22380 and contains no Python-specific CFG behavior change.

## Validation

- `codeql query compile --search-path=. java/ql/consistency-queries/CfgConsistency.ql csharp/ql/consistency-queries/CfgConsistency.ql python/ql/consistency-queries/CfgConsistency.ql`
- `codeql test run --search-path=. --consistency-queries java/ql/consistency-queries -- java/ql/test/library-tests/controlflow/basic` — 28 tests passed
- `codeql test run --search-path=. --consistency-queries csharp/ql/consistency-queries -- csharp/ql/test/library-tests/controlflow/graph` — 13 tests passed
- `codeql test run --search-path=. --consistency-queries python/ql/consistency-queries -- python/ql/test/library-tests/ControlFlow/successors` — 7 tests passed

No invalid abrupt-completion origins or unrelated expected-output churn were found in the three consuming languages.