### PR TITLE
Python: cache shared SSA definition reachability

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/SsaImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/SsaImpl.qll
@@ -256,7 +256,7 @@ private module SsaImplInput implements SsaImplCommon::InputSig<Py::Location, Cfg
   }
 }
 
-import SsaImplCommon::MakeWithCachedLiveness<Py::Location, CfgImpl::Cfg, SsaImplInput> as Impl
+import SsaImplCommon::MakeWithCachedLivenessAndDefinitionReachability<Py::Location, CfgImpl::Cfg, SsaImplInput> as Impl
 
 // Matching the cases in `SsaImplInput.variableWrite` above
 newtype TVariableWrite =

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -253,6 +253,20 @@ private module LivenessCaching implements LivenessCachingSig {
   predicate enabled() { any() }
 }
 
+private signature module DefinitionReachabilityCachingSig {
+  predicate enabled();
+}
+
+private module NoDefinitionReachabilityCaching implements DefinitionReachabilityCachingSig {
+  pragma[inline]
+  predicate enabled() { none() }
+}
+
+private module DefinitionReachabilityCaching implements DefinitionReachabilityCachingSig {
+  pragma[inline]
+  predicate enabled() { any() }
+}
+
 /**
  * Provides an SSA implementation.
  *
@@ -272,7 +286,7 @@ private module LivenessCaching implements LivenessCachingSig {
  */
 private module MakeImpl<
   LocationSig Location, BB::CfgSig<Location> Cfg, InputSig<Location, Cfg::BasicBlock> Input,
-  LivenessCachingSig CacheLiveness>
+  LivenessCachingSig CacheLiveness, DefinitionReachabilityCachingSig CacheDefinitionReachability>
 {
   private import Cfg
   private import Input
@@ -530,7 +544,9 @@ private module MakeImpl<
      * Holds if the SSA definition `def` reaches rank index `rnk` in its own
      * basic block `bb`.
      */
-    predicate ssaDefReachesRank(BasicBlock bb, Definition def, int rnk, SourceVariable v) {
+    private predicate ssaDefReachesRankUncached(
+      BasicBlock bb, Definition def, int rnk, SourceVariable v
+    ) {
       exists(int i |
         rnk = refRank(bb, i, v, Def()) and
         def.definesAt(v, bb, i)
@@ -538,6 +554,28 @@ private module MakeImpl<
       or
       ssaDefReachesRank(bb, def, rnk - 1, v) and
       rnk = refRank(bb, _, v, Read())
+    }
+
+    cached
+    private predicate ssaDefReachesRankCached(
+      BasicBlock bb, Definition def, int rnk, SourceVariable v
+    ) {
+      exists(int i |
+        rnk = refRank(bb, i, v, Def()) and
+        def.definesAt(v, bb, i)
+      )
+      or
+      ssaDefReachesRank(bb, def, rnk - 1, v) and
+      rnk = refRank(bb, _, v, Read())
+    }
+
+    pragma[inline]
+    predicate ssaDefReachesRank(BasicBlock bb, Definition def, int rnk, SourceVariable v) {
+      not CacheDefinitionReachability::enabled() and
+      ssaDefReachesRankUncached(bb, def, rnk, v)
+      or
+      CacheDefinitionReachability::enabled() and
+      ssaDefReachesRankCached(bb, def, rnk, v)
     }
 
     /**
@@ -557,7 +595,9 @@ private module MakeImpl<
      * SSA definition of `v`.
      */
     pragma[nomagic]
-    predicate ssaDefReachesEndOfBlock(BasicBlock bb, Definition def, SourceVariable v) {
+    private predicate ssaDefReachesEndOfBlockUncached(
+      BasicBlock bb, Definition def, SourceVariable v
+    ) {
       exists(int last |
         last = maxRefRank(pragma[only_bind_into](bb), pragma[only_bind_into](v)) and
         ssaDefReachesRank(bb, def, last, v) and
@@ -574,6 +614,36 @@ private module MakeImpl<
         ssaDefReachesEndOfBlock(idom, def, v) and
         liveThrough(idom, bb, v)
       )
+    }
+
+    pragma[nomagic]
+    cached
+    private predicate ssaDefReachesEndOfBlockCached(BasicBlock bb, Definition def, SourceVariable v) {
+      exists(int last |
+        last = maxRefRank(pragma[only_bind_into](bb), pragma[only_bind_into](v)) and
+        ssaDefReachesRank(bb, def, last, v) and
+        liveAtExit(bb, v)
+      )
+      or
+      exists(BasicBlock idom |
+        // The construction of SSA form ensures that each read of a variable is
+        // dominated by its definition. An SSA definition therefore reaches a
+        // control flow node if it is the _closest_ SSA definition that dominates
+        // the node. If two definitions dominate a node then one must dominate the
+        // other, so therefore the definition of _closest_ is given by the dominator
+        // tree. Thus, reaching definitions can be calculated in terms of dominance.
+        ssaDefReachesEndOfBlock(idom, def, v) and
+        liveThrough(idom, bb, v)
+      )
+    }
+
+    pragma[inline]
+    predicate ssaDefReachesEndOfBlock(BasicBlock bb, Definition def, SourceVariable v) {
+      not CacheDefinitionReachability::enabled() and
+      ssaDefReachesEndOfBlockUncached(bb, def, v)
+      or
+      CacheDefinitionReachability::enabled() and
+      ssaDefReachesEndOfBlockCached(bb, def, v)
     }
 
     /**
@@ -2236,7 +2306,7 @@ private module MakeImpl<
 module Make<
   LocationSig Location, BB::CfgSig<Location> Cfg, InputSig<Location, Cfg::BasicBlock> Input>
 {
-  import MakeImpl<Location, Cfg, Input, NoLivenessCaching>
+  import MakeImpl<Location, Cfg, Input, NoLivenessCaching, NoDefinitionReachabilityCaching>
 }
 
 /**
@@ -2247,5 +2317,17 @@ module Make<
 module MakeWithCachedLiveness<
   LocationSig Location, BB::CfgSig<Location> Cfg, InputSig<Location, Cfg::BasicBlock> Input>
 {
-  import MakeImpl<Location, Cfg, Input, LivenessCaching>
+  import MakeImpl<Location, Cfg, Input, LivenessCaching, NoDefinitionReachabilityCaching>
+}
+
+/**
+ * Provides an SSA implementation that caches complete source-variable liveness and
+ * definition-reachability relations.
+ *
+ * Use this when the same SSA instantiation is exposed through multiple cached API stages.
+ */
+module MakeWithCachedLivenessAndDefinitionReachability<
+  LocationSig Location, BB::CfgSig<Location> Cfg, InputSig<Location, Cfg::BasicBlock> Input>
+{
+  import MakeImpl<Location, Cfg, Input, LivenessCaching, DefinitionReachabilityCaching>
 }


### PR DESCRIPTION
## Summary

This is a DCA-only stacked draft above github/codeql#22465. It is based directly on `yoff-python-cache-shared-ssa-liveness` at `8791147a0bc72325c35004ab741442cd7de3122d`; this layer's head is `fc71c20369d455a2ec5fb9969cafeabc62a03ccb`.

The layer contains two commits:

1. `e9bb6ff417c7a5574ef3f1ff84637b029c10e9ca` (`SSA: add opt-in definition reachability caching`) adds an opt-in shared-SSA factory that caches the complete definition-rank and end-of-block reachability fixed points while keeping the default factory demand-specialized.
2. `fc71c20369d455a2ec5fb9969cafeabc62a03ccb` (`Python: cache shared SSA definition reachability`) selects that factory only for Python's main SSA instantiation.

Capture SSA remains uncached: `VariableCapture.qll` continues to instantiate the default `Ssa::Make` factory.

## Exact local evidence

Clean-cache serial controls retained exact BQRS/result hashes and unchanged complete result-generation hashes for the cached relations:

- Airflow CSRF: joins `1,250,313,522 -> 1,243,689,535` (`-6,623,987`, `-0.53%`), with 525 recursive runs removed.
- Nova CSRF: joins `1,087,918,400 -> 1,084,198,621` (`-3,719,779`, `-0.34%`), with 1,691 recursive runs removed.
- Salt unsafe deserialization: joins `2,304,605,194 -> 2,241,319,019` (`-63,286,175`, `-2.75%`), with 6,700 recursive runs removed.

The main rank/end-of-block relations collapse from 2/2, 2/2, and 7/6 recursive materializations respectively to one each.

## Validation

- `codeql query format --check-only -- shared/ssa/codeql/ssa/Ssa.qll python/ql/lib/semmle/python/dataflow/new/internal/SsaImpl.qll`
- `codeql test run --search-path=. -- python/ql/test/library-tests/dataflow-new-ssa/SsaTest.ql python/ql/test/library-tests/dataflow-new-ssa/AdjacentUsesContract.ql`

Both targeted tests pass.

## Cache tradeoff

Tuple pools are unchanged. After clean-cache prewarm plus target and normal cleanup, persistent cache grows by `+7,172 KiB` for Airflow (`363,004 -> 370,176 KiB`, `+1.98%`) and `+14,860 KiB` for Salt (`509,484 -> 524,344 KiB`, `+2.92%`).

This draft is for DCA measurement only. It is not a merge proposal.