### PR TITLE
Python: cache shared CFG scope for DCA validation

### DIFF
--- a/python/ql/lib/semmle/python/controlflow/internal/Cfg.qll
+++ b/python/ql/lib/semmle/python/controlflow/internal/Cfg.qll
@@ -68,6 +68,7 @@ class ControlFlowNode extends CfgImpl::ControlFlowNode {
   BasicBlock getBasicBlock() { result = super.getBasicBlock() }
 
   /** Gets the scope containing this flow node. */
+  cached
   Py::Scope getScope() { result = super.getEnclosingCallable().asScope() }
 
   /** Gets the enclosing module. */


### PR DESCRIPTION
## Purpose

This is a **DCA-only aggregate validation layer, not a merge or publication proposal**. It depends on draft PR #148 and is intended only to measure the combined candidate. No DCA was launched from this session.

- Exact base: `yoff-definition-reach-cache` at `fc71c20369d455a2ec5fb9969cafeabc62a03ccb`
- Exact candidate: `d828b0e2d6de619f1c095b2c82a28a4ee138a2a5`

## Delta

One production line adds `cached` to Python `Cfg::ControlFlowNode.getScope/0`, after all shared-CFG semantic inputs and before Python SSA/dataflow staged consumers.

Excluded: generic shared control-flow caching, `BasicBlock.getNode`, `asPyExpr`, dominance, the rejected inline variant, diagnostic scripts/artifacts, tests/docs not required by this annotation-only change, and unrelated changes.

## Local evidence

Matched `fc71c20` serial controls used `-j1 -M8192 --tuple-counting --keep-full-cache`, with `MissingCallToDel.ql` prewarm followed by Airflow/Nova CSRF or Salt unsafe deserialization.

- Joined tuples: Airflow **-41,663,786 (-3.350%)**; Nova **-47,510,499 (-4.3821%)**; Salt **-55,507,401 (-2.477%)**.
- Exact direct scope relations, baseline = candidate: Airflow 4,156,094 rows, BQRS `79f6d1a5c89788a1d60e1a72b56276bd`; Nova 3,363,505 rows, `9c8cd9a9ebffaabc152b268c412a4754`; Salt 6,000,239 rows, `d4380a7365e04f04034c8041ea54ac91`.
- Exact prewarm outputs: Airflow/Nova BQRS `f8b4bdd150cbfa338a8fd46f2f79ff41`; Salt `34e91d9b25edd865f736f36a21e6d8ac`.
- Exact target outputs: Airflow/Nova BQRS `05953605a10e3fd0994ef0f614ff5abd`; Salt `2a514e093aae140a14f6bf77beebe1ad`. Target cache hits were exactly 4,045,061 Airflow and 3,363,505 Nova rows.
- Three repeated Airflow evaluator runs: median serial evaluator total **-0.860%** (70.804 s to 70.195 s); tuple counts were stable within each variant.
- Post-cleanup relation cache: Airflow **+8,944 KiB (+2.413%)**; Nova **+15,532 KiB (+5.328%)**. Tuple pools were unchanged.
- Rejected inline variant: **+99,308,290 joins (+7.985%)** on Airflow, despite exact BQRS.

## Validation

- `codeql query format --check-only -- python/ql/lib/semmle/python/controlflow/internal/Cfg.qll`
- `codeql test run --search-path=. -- python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions python/ql/test/library-tests/ControlFlow/store-load python/ql/test/library-tests/dataflow-new-ssa python/ql/test/library-tests/dataflow-new-ssa-vs-legacy` — all 5 tests passed.