### PR TITLE
Cache Python shared-CFG node mapping for DCA

### DIFF
--- a/python/ql/lib/semmle/python/controlflow/internal/Cfg.qll
+++ b/python/ql/lib/semmle/python/controlflow/internal/Cfg.qll
@@ -35,6 +35,7 @@ private import codeql.controlflow.SuccessorType
  */
 class ControlFlowNode extends CfgImpl::ControlFlowNode {
   /** Gets the syntactic element corresponding to this flow node, if any. */
+  cached
   Py::AstNode getNode() {
     exists(CfgImpl::Ast::AstNode n | this.injects(n) | result = CfgImpl::astNodeToPyNode(n))
   }


### PR DESCRIPTION
## Status

This is a **DCA-only aggregate follow-up, not a merge proposal**. The broad fleet DCA is pending, and this PR remains draft.

- Baseline: exact SHA `d828b0e2d6de619f1c095b2c82a28a4ee138a2a5`
- Candidate: one line adding `cached` to the truthful `Cfg::ControlFlowNode.getNode()` mapping

## Local deterministic evidence

Combined joins:

- Airflow: -84,191,098 (-7.004%)
- Nova unsafe: -72,724,390 (-6.304%)
- Nova NoSQL: -71,249,141 (-6.313%)

Exact target BQRS and partition equality were confirmed.

Target cache hits:

- Airflow: 2,077,558
- Nova: 1,694,178

Post-cleanup cache/DB:

- Airflow: -1,244 KiB
- Nova unsafe: +4,776 KiB (+1.59%)
- Nova NoSQL: +13,244 KiB (+4.41%)

Tuple pools were unchanged.