### PR TITLE
Python: prefilter directly controlled SSA uses

### DIFF
--- a/python/ql/src/semmle/python/functions/ModificationOfParameterWithDefaultCustomizations.qll
+++ b/python/ql/src/semmle/python/functions/ModificationOfParameterWithDefaultCustomizations.qll
@@ -143,6 +143,12 @@ module ModificationOfParameterWithDefault {
     }
   }
 
+  private predicate directlyControlledUse(
+    DataFlow::GuardNode guard, Cfg::NameNode use, boolean branch
+  ) {
+    guard != use and guard.controlsBlock(use.getBasicBlock(), branch)
+  }
+
   /** Holds if `barrier` is a use guarded by a direct truthiness check on `branch`. */
   private predicate directGuardedUse(DataFlow::ExprNode barrier, boolean branch) {
     exists(
@@ -150,10 +156,9 @@ module ModificationOfParameterWithDefault {
       Cfg::NameNode use
     |
       checked = guard and
+      directlyControlledUse(guard, use, branch) and
       SsaImpl::AdjacentUses::useOfDef(def, checked) and
       SsaImpl::AdjacentUses::useOfDef(def, use) and
-      checked != use and
-      guard.controlsBlock(use.getBasicBlock(), branch) and
       barrier.asCfgNode() = use
     )
   }


### PR DESCRIPTION
## Summary

- Materialize the small `(guard, use, branch)` control relation before matching shared-SSA definitions.
- Bind both definition and use for the second `AdjacentUses::useOfDef` lookup.
- Preserve exact guarded-use and query results while avoiding the fused same-definition use-pair expansion.

Stacked directly on draft #154 at `d75f96aca016100826c64a5e8185ea63fdae8edf`.

## Evidence

FreeCAD `py/modification-of-default-value`:

- Maximum guarded-use intermediate: **1,581,023,259 -> 553,851** rows (**-99.965%**).
- `directGuardedUse`: exactly **4,993 rows** before and after.
- Decoded output SHA-256: `61120da95b48e6a9f3afbbcf82d54fd2775d695a501ae5bc357aefe46410583e`.
- Raw BQRS SHA-256: `613ba8a9cac7fae61d2a911178de7eca60e70575dbf4db9dfb526bfb0a4c8967` before and after.
- Warm: **70.603s / 3,314,607,744 joins -> 9.086-9.182s / 153,659,310 joins**.
- Cold: **124.350s / 4,318,981,140 joins -> 64.682s / 1,161,966,394 joins**.
- Combined cold+warm joins: **-82.765%**.
- Post-cleanup cache: **+1,568 KiB**; no new cache annotation; warm relation-cache hits remain 209.

Independent controls:

- M-moire combined cold+warm joins: **-0.684%**, exact decoded output.
- Nova combined cold+warm joins: **-3.079%**, exact decoded output.
- FreeCAD CommandInjection control: exact historical decoded output.
- Airflow `py/clear-text-logging-sensitive-data`: byte-identical QL hash/DIL/RA and therefore unaffected; the local control retains 130 results and the 21.7 MB BQRS production flip.

The helper adds two small pipeline starts per evaluation; these replace the dominant expansion. An inline-only formulation was rejected because it compiled to the original RA and retained the 1.581B-row join.

## Validation

- `codeql query format --check-only python/ql/src/semmle/python/functions/ModificationOfParameterWithDefaultCustomizations.qll`
- `codeql test run -j1 python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault` (3 tests passed, including `BarrierGuardSpecialization.ql`)
- FreeCAD `python/ql/src/Security/CWE-078/CommandInjection.ql` control (exact output)

The code commit retains validated stable patch-id `3307faf03796b54c45c6ae0975a083a97811e775`.
